### PR TITLE
feat(main): add main scene and script

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://scripts/main.gd" type="Script" id=1]
+[ext_resource path="res://assets/tiles/plain.png" type="Texture2D" id=2]
+
+[sub_resource type="TileSet" id=1]
+0/name = "Plain"
+0/texture = ExtResource(2)
+
+[node name="Main" type="Node2D"]
+script = ExtResource(1)
+
+[node name="TileMap" type="TileMap" parent="."]
+tile_set = SubResource(1)

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -1,0 +1,25 @@
+extends Node2D
+
+const WORLD_SIZE := Vector2i(2000, 2000)
+
+@onready var tile_map: TileMap = $TileMap
+@onready var capital: Node2D = Node2D.new()
+
+func _ready() -> void:
+    # Populate the world with plain tiles
+    var tile_id := 0
+    for x in range(WORLD_SIZE.x):
+        for y in range(WORLD_SIZE.y):
+            tile_map.set_cell(0, Vector2i(x, y), tile_id)
+
+    # Position the capital at the center of the world
+    capital.name = "Capital"
+    capital.position = WORLD_SIZE / 2
+    add_child(capital)
+
+func _process(delta: float) -> void:
+    _simulate_step(delta)
+
+func _simulate_step(_delta: float) -> void:
+    # Placeholder for the simulation loop
+    pass


### PR DESCRIPTION
## Summary
- add root scene with TileMap and plain tile
- stub simulation script with world size constant and capital placement

## Testing
- `godot --version` *(fails: command not found)*
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6289b2e2c8330b078c50ecf687cd0