### PR TITLE
feat: add influence system to track city zones

### DIFF
--- a/scripts/capital.gd
+++ b/scripts/capital.gd
@@ -9,6 +9,9 @@ func add_resource(resource_type: String, amount: int) -> void:
 func get_resource(resource_type: String) -> int:
     return resources.get(resource_type, 0)
 
+func _ready() -> void:
+    Influence.add_zone(global_position, influence_radius)
+
 func spawn_builder() -> Node:
     var builder_scene: PackedScene = preload("res://scenes/Builder.tscn")
     var builder = builder_scene.instantiate()

--- a/scripts/city.gd
+++ b/scripts/city.gd
@@ -1,0 +1,7 @@
+extends Node2D
+
+@export var influence_radius: float = 250.0
+
+func _ready() -> void:
+    Influence.add_zone(global_position, influence_radius)
+

--- a/scripts/systems/influence.gd
+++ b/scripts/systems/influence.gd
@@ -1,0 +1,14 @@
+extends Node
+class_name Influence
+
+static var zones: Array[Dictionary] = []
+
+static func add_zone(position: Vector2, radius: float) -> void:
+    zones.append({"position": position, "radius": radius})
+
+static func is_influenced(position: Vector2) -> bool:
+    for zone in zones:
+        if position.distance_to(zone["position"]) <= zone["radius"]:
+            return true
+    return false
+


### PR DESCRIPTION
## Summary
- add global influence system to store city influence zones
- register capital and city zones on creation

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a62b1a29e4833087932072e1ced8c4