### PR TITLE
feat(city): add city scene with influence and road link

### DIFF
--- a/scenes/City.tscn
+++ b/scenes/City.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://city"]
+
+[ext_resource path="res://assets/sprites/city.png" type="Texture2D" id=1]
+[ext_resource path="res://scripts/city.gd" type="Script" id=2]
+
+[node name="City" type="Area2D"]
+script = ExtResource(2)
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource(1)

--- a/scripts/city.gd
+++ b/scripts/city.gd
@@ -1,7 +1,17 @@
-extends Node2D
+extends Area2D
+
+signal road_connected(road: Node)
 
 @export var influence_radius: float = 250.0
+var occupied: bool = false
+var connected_road: Node = null
 
-func _ready() -> void:
+func occupy() -> void:
+    if occupied:
+        return
     Influence.add_zone(global_position, influence_radius)
+    occupied = true
 
+func connect_road(road: Node) -> void:
+    connected_road = road
+    road_connected.emit(road)


### PR DESCRIPTION
## Summary
- add City.tscn with Area2D and sprite
- implement city.gd with influence radius, occupancy, and road connection signal

## Testing
- `godot --headless --check` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a62c5224c483309d17d90794177b86