### PR TITLE
feat(builder): implement builder exploration cycle

### DIFF
--- a/scenes/Builder.tscn
+++ b/scenes/Builder.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://builder"]
+
+[ext_resource path="res://assets/sprites/builder.png" type="Texture2D" id=1]
+[ext_resource path="res://scripts/builder.gd" type="Script" id=2]
+
+[node name="Builder" type="Node2D"]
+script = ExtResource(2)
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource(1)

--- a/scripts/builder.gd
+++ b/scripts/builder.gd
@@ -1,10 +1,57 @@
 extends Node2D
 class_name Builder
 
+signal cycle_completed(city: Node)
+
+@export var speed: float = 100.0
+
 var built_city: Node = null
 var return_path: Array[Vector2] = []
+var travel_path: Array[Vector2] = []
+var returning: bool = false
+var direction: Vector2 = Vector2.ZERO
 
-func return_to_capital() -> void:
+func _ready() -> void:
+    randomize()
+    direction = Vector2.RIGHT.rotated(randf() * TAU).normalized()
+    return_path.append(global_position)
+
+func _physics_process(delta: float) -> void:
+    if returning:
+        _return_step(delta)
+    else:
+        _explore_step(delta)
+
+func _explore_step(delta: float) -> void:
+    global_position += direction * speed * delta
+    return_path.append(global_position)
+    if not Influence.is_influenced(global_position):
+        _build_city()
+        travel_path = return_path.duplicate()
+        travel_path.reverse()
+        returning = true
+
+func _return_step(delta: float) -> void:
+    if travel_path.is_empty():
+        _arrive_at_capital()
+        return
+    var target: Vector2 = travel_path[0]
+    var to_target: Vector2 = target - global_position
+    var max_dist: float = speed * delta
+    if to_target.length() <= max_dist:
+        global_position = target
+        travel_path.remove_at(0)
+    else:
+        global_position += to_target.normalized() * max_dist
+
+func _build_city() -> void:
+    var city_scene: PackedScene = preload("res://scenes/City.tscn")
+    built_city = city_scene.instantiate()
+    built_city.global_position = global_position
+    get_tree().current_scene.add_child(built_city)
+
+func _arrive_at_capital() -> void:
     if built_city and return_path.size() > 0:
         Roads.create_road(return_path, built_city)
+    cycle_completed.emit(built_city)
     queue_free()

--- a/scripts/capital.gd
+++ b/scripts/capital.gd
@@ -16,5 +16,13 @@ func spawn_builder() -> Node:
     var builder_scene: PackedScene = preload("res://scenes/Builder.tscn")
     var builder = builder_scene.instantiate()
     builder.global_position = global_position
+    builder.cycle_completed.connect(_on_builder_cycle_completed)
     get_tree().current_scene.add_child(builder)
     return builder
+
+func _on_builder_cycle_completed(city: Node) -> void:
+    spawn_inhabitant(city)
+
+func spawn_inhabitant(_city: Node) -> void:
+    # TODO: implement inhabitant spawning
+    pass


### PR DESCRIPTION
## Summary
- add Builder.tscn scene using builder sprite
- implement builder exploration, city creation and return path
- connect capital to builder cycle_completed to trigger inhabitant

## Testing
- `godot --version` *(fails: command not found)*
- `gdformat --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a62fa0a4a88330ac4a9d1467aff9c9