### PR TITLE
Add inhabitant unit that settles cities

### DIFF
--- a/scripts/capital.gd
+++ b/scripts/capital.gd
@@ -2,6 +2,7 @@ extends Node2D
 
 @export var influence_radius: float = 250.0
 var resources: Dictionary = {}
+const Inhabitant = preload("res://scripts/inhabitant.gd")
 
 func add_resource(resource_type: String, amount: int) -> void:
     resources[resource_type] = resources.get(resource_type, 0) + amount
@@ -24,5 +25,7 @@ func _on_builder_cycle_completed(city: Node) -> void:
     spawn_inhabitant(city)
 
 func spawn_inhabitant(_city: Node) -> void:
-    # TODO: implement inhabitant spawning
-    pass
+    var inhabitant: Node2D = Inhabitant.new()
+    inhabitant.global_position = global_position
+    inhabitant.set_path(Roads.get_path_to(_city), _city)
+    get_tree().current_scene.add_child(inhabitant)

--- a/scripts/inhabitant.gd
+++ b/scripts/inhabitant.gd
@@ -1,0 +1,30 @@
+extends Node2D
+class_name Inhabitant
+
+@export var speed: float = 100.0
+var path: Array[Vector2] = []
+var city: Node = null
+
+func _ready() -> void:
+    var sprite := Sprite2D.new()
+    sprite.texture = preload("res://assets/sprites/inhabitant.png")
+    add_child(sprite)
+
+func set_path(path_points: Array[Vector2], target_city: Node) -> void:
+    path = path_points.duplicate()
+    city = target_city
+
+func _physics_process(delta: float) -> void:
+    if path.is_empty():
+        if city:
+            city.occupy()
+        queue_free()
+        return
+    var target: Vector2 = path[0]
+    var to_target: Vector2 = target - global_position
+    var max_dist: float = speed * delta
+    if to_target.length() <= max_dist:
+        global_position = target
+        path.remove_at(0)
+    else:
+        global_position += to_target.normalized() * max_dist


### PR DESCRIPTION
## Summary
- Implement `Inhabitant` node that travels along road paths and occupies cities
- Spawn inhabitants from the capital when builders finish, using road path to target city

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a630f464188330b3f7d6dd28d04b5c