### PR TITLE
Fix scene setup and typed paths

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,5 +1,4 @@
-
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=3 format=3 uid="uid://main"]
 
 [ext_resource path="res://scripts/main.gd" type="Script" id=1]
 [ext_resource path="res://assets/tiles/plain.png" type="Texture2D" id=2]
@@ -7,20 +6,10 @@
 [sub_resource type="TileSet" id=1]
 0/name = "Plain"
 0/texture = ExtResource(2)
+0/region = Rect2i(0, 0, 32, 32)
 
 [node name="Main" type="Node2D"]
 script = ExtResource(1)
-
-
-
-[gd_scene load_steps=2 format=3 uid="uid://main"]
-
-[ext_resource path="res://scripts/main.gd" type="Script" id=1]
-
-[node name="Main" type="Node2D"]
-script = ExtResource(1)
-
 
 [node name="TileMap" type="TileMap" parent="."]
 tile_set = SubResource(1)
-

--- a/scripts/builder.gd
+++ b/scripts/builder.gd
@@ -10,10 +10,11 @@ var return_path: Array[Vector2] = []
 var travel_path: Array[Vector2] = []
 var returning: bool = false
 var direction: Vector2 = Vector2.ZERO
+var rng := RandomNumberGenerator.new()
 
 func _ready() -> void:
-    randomize()
-    direction = Vector2.RIGHT.rotated(randf() * TAU).normalized()
+    rng.randomize()
+    direction = Vector2.RIGHT.rotated(rng.randf() * TAU).normalized()
     return_path.append(global_position)
 
 func _physics_process(delta: float) -> void:
@@ -27,7 +28,7 @@ func _explore_step(delta: float) -> void:
     return_path.append(global_position)
     if not Influence.is_influenced(global_position):
         _build_city()
-        travel_path = return_path.duplicate()
+        travel_path = return_path.duplicate() as Array[Vector2]
         travel_path.reverse()
         returning = true
 

--- a/scripts/inhabitant.gd
+++ b/scripts/inhabitant.gd
@@ -11,7 +11,7 @@ func _ready() -> void:
     add_child(sprite)
 
 func set_path(path_points: Array[Vector2], target_city: Node) -> void:
-    path = path_points.duplicate()
+    path = path_points.duplicate() as Array[Vector2]
     city = target_city
 
 func _physics_process(delta: float) -> void:

--- a/scripts/systems/roads.gd
+++ b/scripts/systems/roads.gd
@@ -4,7 +4,7 @@ class_name Roads
 static var roads: Dictionary = {}
 
 static func create_road(points: Array[Vector2], city: Node) -> void:
-    roads[city] = points.duplicate()
+    roads[city] = points.duplicate() as Array[Vector2]
 
 static func get_path_to(city: Node) -> Array[Vector2]:
-    return roads.get(city, [])
+    return roads.get(city, []) as Array[Vector2]


### PR DESCRIPTION
## Summary
- Fix malformed `Main.tscn` and define tile region
- Use `RandomNumberGenerator` and typed paths in builder and inhabitant
- Return typed road paths from Roads system

## Testing
- `godot --headless --quit --path .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a638c441888330805da990a79413ad